### PR TITLE
Replace removed resources.ToCSS with css.Sass

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
   {{ $sass := resources.Get "sass/main.scss" }}
-  {{ $style := $sass | resources.ToCSS | minify | fingerprint }}
+  {{ $style := $sass | css.Sass | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
   <link rel="canonical" href="{{ .Permalink }}">
   {{ $siteTitle := .Site.Title }}


### PR DESCRIPTION
## Summary

Hugo removed \`resources.ToCSS\` alongside LibSass around v0.139. Sites consuming this theme fail to build on modern Hugo with:

\`\`\`
error building site: render: failed to render pages: render of "/" failed:
... executing "_partials/head.html" at <resources>: can't evaluate field ToCSS in type interface {}
\`\`\`

Swapping to \`css.Sass\` (Dart Sass is the only remaining transpiler; shipped with Hugo extended + a \`dart-sass\` install in CI) restores the pipeline. Behavior is identical for existing SCSS input.

## Context

Spotted while finishing the Jekyll→Hugo cleanup on \`harringa.com\` ([PR #44](https://github.com/justinharringa/harringa.com/pull/44)): bumping \`HUGO_VERSION\` from 0.120.4 to 0.160.1 broke the build on this line. That PR will bump this theme submodule to the merge commit from here.

## Test plan

- [ ] Consumer site's PR build check (harringa.com #44) goes green after this is merged and the submodule pointer is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)