### PR TITLE
Don't double-print the site title on the home page

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
+  <title>{{ if and .Title (ne .Title .Site.Title) }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   <!-- TODO: GET AN EXCERPT INSTEAD LIKE IN JEKYLL?? -->
   <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.SiteDescription }}{{ end }}">
   <meta name="author" content="Justin Harringa"> <!-- TODO: Dynamic Author -->


### PR DESCRIPTION
## Problem

On the home page, the rendered \`<title>\` is the site title twice:

\`\`\`
<title>Harringa.com | Harringa.com</title>
\`\`\`

That's because Hugo defaults \`.Title\` to \`.Site.Title\` on home pages, and the previous template unconditionally prepended \`.Title\` whenever it was truthy:

\`\`\`
<title>{{ if .Title }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
\`\`\`

## Fix

One-line change — only prepend \`.Title\` when it differs from \`.Site.Title\`:

\`\`\`
<title>{{ if and .Title (ne .Title .Site.Title) }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
\`\`\`

Using \`ne\` instead of \`.IsHome\` covers the edge case where a non-home page happens to set its title to the site title (still don't want to double-print there either).

## Test plan

Verified locally against harringa.com content:

| Page kind | Rendered \`<title>\` |
|---|---|
| Home (\`/\`) | \`<title>Harringa.com</title>\` |
| Post (\`/posts/2011/11/15/apples-itunes-match-is-live/\`) | \`<title>Apple's iTunes Match is live! | Harringa.com</title>\` |
| 404 (\`/404.html\`) | \`<title>404 Page not found | Harringa.com</title>\` |

Surfaced while diagnosing harringa.com rendering oddities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)