### PR TITLE
Read author from page/site params instead of hardcoding

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
   <title>{{ if and .Title (ne .Title .Site.Title) }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   <!-- TODO: GET AN EXCERPT INSTEAD LIKE IN JEKYLL?? -->
   <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.SiteDescription }}{{ end }}">
-  <meta name="author" content="Justin Harringa"> <!-- TODO: Dynamic Author -->
+  {{ with (or .Params.author .Site.Params.author) }}<meta name="author" content="{{ . }}">{{ end }}
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">


### PR DESCRIPTION
Closes #1.

## Problem

\`layouts/partials/head.html\` previously rendered a hardcoded author meta tag:

\`\`\`html
<meta name=\"author\" content=\"Justin Harringa\"> <!-- TODO: Dynamic Author -->
\`\`\`

Two issues:
1. **Leaks the theme author's name into every consumer site** — same anti-pattern as the hardcoded \`UA-4900256-1\` that #7 cleaned up.
2. **Ignores per-post \`author:\` front matter** — many posts on harringa.com set \`author: Justin\` explicitly, but the rendered tag said \"Justin Harringa\" regardless.

## Fix

One-line change: read from page-level params first, fall back to site-level, omit the meta tag entirely if neither is set.

\`\`\`go
{{ with (or .Params.author .Site.Params.author) }}<meta name=\"author\" content=\"{{ . }}\">{{ end }}
\`\`\`

## Test plan

Verified against harringa.com content (\`params.author: Justin Harringa\` in site config; some posts override with \`author: Justin\` in front matter):

| Page | \`.Params.author\` | \`.Site.Params.author\` | Rendered |
|---|---|---|---|
| Home (\`/\`) | — | \`Justin Harringa\` | \`<meta name=\"author\" content=\"Justin Harringa\">\` |
| Post with front-matter author (\`/posts/2011/11/15/apples-itunes-match-is-live/\`) | \`Justin\` | \`Justin Harringa\` | \`<meta name=\"author\" content=\"Justin\">\` |
| Post without front-matter author (\`/posts/2019/06/19/from-jekyll-to-hugo/\`) | — | \`Justin Harringa\` | \`<meta name=\"author\" content=\"Justin Harringa\">\` |

If a consumer neither sets \`.Params.author\` nor \`.Site.Params.author\`, no tag is emitted (cleaner than an empty \`content=\"\"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)