### PR TITLE
Add ReadingTime to posts (togglable)

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -5,7 +5,10 @@
 {{ define "main" }}
 {{ $dateFormat := default "Jan 2, 2006" (index .Site.Params "date_format") }}
   <h1 class="mt-3">{{ .Title }}</h1>
-  <h5 class="text-muted">{{ if not .Date.IsZero }}{{ .Date.Format $dateFormat }}{{ end }}</h5>
+  {{ $meta := slice }}
+  {{ if not .Date.IsZero }}{{ $meta = $meta | append (.Date.Format $dateFormat) }}{{ end }}
+  {{ if default true .Site.Params.showReadingTime }}{{ $meta = $meta | append (printf "%d min read" .ReadingTime) }}{{ end }}
+  {{ with $meta }}<h5 class="text-muted">{{ delimit . " · " }}</h5>{{ end }}
   {{ .Content }}
   {{ template "_internal/disqus.html" . }}
 {{ end }}


### PR DESCRIPTION
Closes #4.

## Summary

Renders reading time alongside the date under the post title, e.g.:

\`\`\`
Jun 19, 2019 · 3 min read
\`\`\`

Honors \`.Site.Params.showReadingTime\` (defaults to \`true\`); consumer sites can disable with:

\`\`\`yaml
params:
  showReadingTime: false
\`\`\`

## Implementation

Uses a \`slice\` + \`delimit\` pattern so the \"·\" separator only appears when both values render. Handles three edge cases cleanly:

| Case | Rendered |
|---|---|
| Both (default) | \`Jun 19, 2019 · 3 min read\` |
| \`showReadingTime: false\` | \`Jun 19, 2019\` |
| Post with no \`.Date\` | \`3 min read\` |
| \`showReadingTime: false\` AND no \`.Date\` | (no \`<h5>\` at all) |

## Test plan

Verified locally against harringa.com content:

- \`/posts/2008/05/03/lasik-update/\` — \`May 3, 2008 · 1 min read\`
- \`/posts/2019/06/19/from-jekyll-to-hugo/\` — \`Jun 19, 2019 · 3 min read\`
- \`/posts/2011/11/15/apples-itunes-match-is-live/\` — \`Nov 14, 2011 · 3 min read\`

Out of scope: showing reading time on list/summary views — posts listing intentionally stays lighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)