### PR TITLE
Add exampleSite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  example-site-build:
+    runs-on: ubuntu-latest
+    env:
+      # renovate: datasource=github-releases depName=gohugoio/hugo extractVersion=^v(?<version>.+)$
+      HUGO_VERSION: 0.160.1
+    steps:
+      - name: Checkout (into themes/bota so exampleSite can resolve the theme)
+        uses: actions/checkout@v6
+        with:
+          path: themes/bota
+      - name: Install Hugo CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${HUGO_VERSION}" \
+            --repo gohugoio/hugo \
+            --pattern "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
+            --dir "${RUNNER_TEMP}"
+          tar -xzf "${RUNNER_TEMP}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" -C "${RUNNER_TEMP}"
+          sudo install -m 0755 "${RUNNER_TEMP}/hugo" /usr/local/bin/hugo
+      - name: Build exampleSite
+        working-directory: themes/bota/exampleSite
+        run: hugo --themesDir ../.. --destination ./public --printPathWarnings

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+/public
+/resources
+.hugo_build.lock

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,0 +1,27 @@
+baseURL: https://example.com
+languageCode: en-us
+title: Bota Theme Example
+theme: bota
+
+permalinks:
+  posts: posts/:year/:month/:title/
+
+taxonomies:
+  category: categories
+  tag: tags
+
+params:
+  author: Example Author
+  SiteDescription: Example site used by CI to exercise the bota theme's templates.
+  blogPostTaxonomy: posts
+
+menu:
+  main:
+  - name: Blog Posts
+    url: /posts/
+    weight: -100
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true

--- a/exampleSite/content/posts/hello-world.md
+++ b/exampleSite/content/posts/hello-world.md
@@ -1,0 +1,17 @@
+---
+title: Hello World
+date: 2026-01-01
+author: Example Author
+tags:
+  - sample
+categories:
+  - getting-started
+---
+
+This is a sample post in the theme's example site. It exists so CI can
+verify that the theme's templates (baseof, single, list, summary, head,
+header, footer, icon-social) render without errors against a minimal
+but complete site.
+
+Second paragraph so that reading time computes to something non-zero
+on short-but-not-empty content.

--- a/exampleSite/data/social/github.yaml
+++ b/exampleSite/data/social/github.yaml
@@ -1,0 +1,3 @@
+Name: GitHub
+UserName: example
+URL: github.com


### PR DESCRIPTION
## Summary

Theme had no CI — every template change relied on downstream consumers (harringa.com) noticing failures, which is how [bota-hugo-theme#5](https://github.com/justinharringa/bota-hugo-theme/pull/5) (\`resources.ToCSS\` removal) and [bota-hugo-theme#6](https://github.com/justinharringa/bota-hugo-theme/issues/6) (\`.Site.Data\` deprecation) both surfaced. This PR fixes that.

## Changes

### \`exampleSite/\` — minimal but complete

- \`config.yaml\` with \`theme: bota\`, the \`blogPostTaxonomy: posts\` param harringa.com uses, menu, goldmark unsafe rendering, taxonomy definitions.
- \`content/posts/hello-world.md\` — sample post so \`posts/single.html\`, \`posts/list.html\`, \`_default/summary.html\` all exercise.
- \`data/social/github.yaml\` — so \`footer.html\`'s \`{{ range hugo.Data.social }}\` iterates something.
- \`.gitignore\` — drops the usual Hugo output (\`public/\`, \`resources/\`, \`.hugo_build.lock\`).

### \`.github/workflows/ci.yml\`

- Triggered on push/PR against \`master\`.
- Installs Hugo via \`gh release download\` (same pattern as harringa.com's workflow); \`HUGO_VERSION\` Renovate-annotated.
- Checks out the repo at \`themes/bota/\` (via \`actions/checkout\`'s \`path:\` option) so \`--themesDir ../..\` from \`themes/bota/exampleSite/\` resolves to a dir containing \`bota/\`.
- Runs \`hugo --destination ./public --printPathWarnings\` and exits non-zero on failure.

## Test plan

Verified locally — \`cd exampleSite && hugo --themesDir ../..\` exits 0, 15 pages, **zero warnings**. Rendered output sampled:

- \`<title>Hello World | Bota Theme Example</title>\` — title prefix appears correctly (page title ≠ site title)
- \`<meta name=\"author\" content=\"Example Author\">\` — front-matter author override working
- \`<h5 class=\"text-muted\">Jan 1, 2026 · 1 min read</h5>\` — date + reading time
- Footer iterates 1 social icon (GitHub)

## Follow-ups (not in this PR)

- Hugo version matrix (\`min_version\` floor from \`theme.toml\` + latest) — nice-to-have.
- More exampleSite content (tag pages, category pages, 404) to exercise more layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)