### PR TITLE
Upgrade Font Awesome 4.5.0 to 6.5.1

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,5 +10,5 @@
             {{ .Render "content" }}
         {{ end }}
     {{ end }}
-    <p class="rss-subscribe"><a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}">Subscribe via RSS <i class="fa fa-rss"></i></a></p>
+    <p class="rss-subscribe"><a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}">Subscribe via RSS <i class="fas fa-rss"></i></a></p>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,5 +13,5 @@
         {{ end }}
       {{ end }}
     {{ end }}
-    <p class="rss-subscribe">See all <a href="{{ $blogPostTaxonomy | relLangURL }}/">blog posts</a> or <a href="{{ printf "%s/%s" $blogPostTaxonomy "index.xml" | relLangURL }}">subscribe via RSS <i class="fa fa-rss"></i></a></p>
+    <p class="rss-subscribe">See all <a href="{{ $blogPostTaxonomy | relLangURL }}/">blog posts</a> or <a href="{{ printf "%s/%s" $blogPostTaxonomy "index.xml" | relLangURL }}">subscribe via RSS <i class="fas fa-rss"></i></a></p>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
   {{ with (or .Params.author .Site.Params.author) }}<meta name="author" content="{{ . }}">{{ end }}
   <link rel="shortcut icon" href="/favicon.ico">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer">
   {{ $sass := resources.Get "sass/main.scss" }}
   {{ $style := $sass | css.Sass | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">

--- a/layouts/partials/icon-social.html
+++ b/layouts/partials/icon-social.html
@@ -1,5 +1,5 @@
 <a href="https://{{ .URL }}/{{ .UserName }}">
     <span class="fa-stack fa-lg" aria-label="{{ .Name | lower}}">
-        <i class="fa fa-circle fa-stack-2x"></i>
-        <i class="fa fa-{{ .Name | lower }} fa-stack-1x fa-inverse"></i>
+        <i class="fas fa-circle fa-stack-2x"></i>
+        <i class="fab fa-{{ .Name | lower }} fa-stack-1x fa-inverse"></i>
     </span></a>

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -12,5 +12,5 @@
         {{ end }}
     {{ end }}
     <!--</ul>-->
-    <p class="rss-subscribe"><a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}">Subscribe via RSS <i class="fa fa-rss"></i></a></p>
+    <p class="rss-subscribe"><a href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}">Subscribe via RSS <i class="fas fa-rss"></i></a></p>
 {{ end }}


### PR DESCRIPTION
Closes #9.

## Summary

Theme loaded Font Awesome 4.5.0 from \`maxcdn.bootstrapcdn.com\` — a CDN that was retired in 2020 (browsers silently tolerated the 404'd stylesheet). This PR switches to cdnjs for FA **6.5.1**.

FA 6 requires an explicit style prefix on every icon:

| Was | Now |
|---|---|
| \`<i class=\"fa fa-circle\">\` | \`<i class=\"fas fa-circle\">\` (solid) |
| \`<i class=\"fa fa-rss\">\` | \`<i class=\"fas fa-rss\">\` (solid) |
| \`<i class=\"fa fa-github\">\` | \`<i class=\"fab fa-github\">\` (brand) |

## Files touched

- \`layouts/partials/head.html\` — CDN link updated to \`https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\`
- \`layouts/partials/icon-social.html\` — \`fa fa-circle\` → \`fas fa-circle\`; the per-account \`fa fa-{{ .Name | lower }}\` pattern becomes \`fab fa-{{ .Name | lower }}\` since social-media icons are all brand icons
- \`layouts/index.html\`, \`layouts/_default/list.html\`, \`layouts/posts/list.html\` — RSS subscribe links: \`fa fa-rss\` → \`fas fa-rss\`

## Consumer impact

No data file changes needed for existing \`data/social/\` entries with standard brand names (\`GitHub\`, \`LinkedIn\`, \`twitter\` all still resolve in FA 6). To use the X logo: \`Name: x-twitter\`.

If any consumer put a solid-icon name (e.g. \`envelope\`, \`rss\`) in \`data/social/\`, it would break — brand-only is the documented contract.

## Test plan

\`cd exampleSite && hugo --themesDir ../..\` still exits 0 with zero warnings. Rendered output sampled:

- \`<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css\" ...>\`
- \`<i class=\"fas fa-rss\">\` in the RSS-subscribe block
- \`<i class=\"fas fa-circle fa-stack-2x\">\` (solid background circle) + \`<i class=\"fab fa-github fa-stack-1x fa-inverse\">\` (brand github logo) in the footer icon stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)