### PR TITLE
Exercise more theme features in exampleSite + CI assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,38 @@ jobs:
       - name: Build exampleSite
         working-directory: themes/bota/exampleSite
         run: hugo --themesDir ../.. --destination ./public --printPathWarnings
+
+      - name: Verify rendered output exercises core features
+        working-directory: themes/bota/exampleSite/public
+        run: |
+          set -euxo pipefail
+
+          post=posts/2026/01/hello-world/index.html
+          post_no_author=posts/2026/02/a-post-with-no-author-front-matter/index.html
+
+          # Hugo's internal google_analytics template wired up via config
+          grep -q 'G-TESTXXXXXX' "$post"
+          grep -q 'googletagmanager' "$post"
+
+          # Hugo's internal disqus template wired up on posts
+          grep -q 'bota-theme-example' "$post"
+
+          # All three data/social/*.yaml entries render in the footer
+          grep -q 'fa-github'   index.html
+          grep -q 'fa-linkedin' index.html
+          grep -q 'fa-twitter'  index.html
+
+          # Dynamic author: per-post override
+          grep -q '<meta name="author" content="Post Author">' "$post"
+
+          # Dynamic author: site-param fallback when no front matter
+          grep -q '<meta name="author" content="Example Author">' "$post_no_author"
+
+          # _default/single.html exercised by a standalone page
+          grep -q '>About</h1>' about/index.html
+
+          # ReadingTime renders alongside date
+          grep -q 'min read' "$post"
+
+          # Home title collapses to site title only (no "Foo | Foo")
+          grep -q '<title>Bota Theme Example</title>' index.html

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -10,6 +10,14 @@ taxonomies:
   category: categories
   tag: tags
 
+# Fake values — exampleSite exists only to exercise templates in CI, not
+# to ship analytics or real Disqus.
+services:
+  googleAnalytics:
+    ID: "G-TESTXXXXXX"
+
+disqusShortname: "bota-theme-example"
+
 params:
   author: Example Author
   SiteDescription: Example site used by CI to exercise the bota theme's templates.
@@ -20,6 +28,9 @@ menu:
   - name: Blog Posts
     url: /posts/
     weight: -100
+  - name: About
+    url: /about/
+    weight: -80
 
 markup:
   goldmark:

--- a/exampleSite/content/about.md
+++ b/exampleSite/content/about.md
@@ -1,0 +1,7 @@
+---
+title: About
+date: 2026-01-01
+---
+
+A standalone (non-post) page that exercises `_default/single.html`
+rather than `posts/single.html`.

--- a/exampleSite/content/posts/hello-world.md
+++ b/exampleSite/content/posts/hello-world.md
@@ -1,7 +1,7 @@
 ---
 title: Hello World
 date: 2026-01-01
-author: Example Author
+author: Post Author
 tags:
   - sample
 categories:

--- a/exampleSite/content/posts/no-explicit-author.md
+++ b/exampleSite/content/posts/no-explicit-author.md
@@ -1,0 +1,10 @@
+---
+title: A Post With No Author Front-Matter
+date: 2026-02-01
+tags:
+  - sample
+---
+
+This post deliberately omits the `author:` field in its front matter so
+that CI can verify the theme's dynamic-author chain falls back to
+`.Site.Params.author`.

--- a/exampleSite/data/social/linkedin.yaml
+++ b/exampleSite/data/social/linkedin.yaml
@@ -1,0 +1,3 @@
+Name: LinkedIn
+UserName: example
+URL: www.linkedin.com/in

--- a/exampleSite/data/social/twitter.yaml
+++ b/exampleSite/data/social/twitter.yaml
@@ -1,0 +1,3 @@
+Name: twitter
+UserName: example
+URL: twitter.com


### PR DESCRIPTION
## Problem

The initial \`exampleSite/\` from #18 gave us \"Hugo builds without errors\" coverage, but several features that harringa.com (and presumably most consumers) rely on were not tested:

| Feature | Covered before? |
|---|---|
| \`posts/single.html\`, \`posts/list.html\`, home, 404, head/footer/header/icon-social | ✓ |
| ReadingTime + dynamic author (per-post override path) | ✓ |
| **Dynamic author — site-param fallback** | ✗ — only post with author front-matter existed |
| **Hugo's internal \`google_analytics\` template (from #7)** | ✗ — no \`googleAnalytics\` in config |
| **Hugo's internal \`disqus\` template** | ✗ — no \`disqusShortname\` in config |
| **Multiple social brand icons** (catches FA6 \`fab fa-linkedin\` regressions) | ✗ — only \`github.yaml\` |
| **\`_default/single.html\`** (vs \`posts/single.html\`) | ✗ — exampleSite had no standalone pages |
| **Home title \"doesn't double\" check** (from #11) | ✗ — grep-level assertion missing |

## Changes

### \`exampleSite/\`

- \`config.yaml\`: fake but valid \`services.googleAnalytics.ID\` and \`disqusShortname\` so the internal templates actually render something in the output.
- \`data/social/linkedin.yaml\` + \`data/social/twitter.yaml\` — footer now iterates three brand icons (GitHub / LinkedIn / Twitter), which meaningfully exercises the FA6 \`fab fa-\{{ name \}}\` pattern.
- \`content/posts/no-explicit-author.md\` — post with no \`author:\` in front matter, so the site-param fallback is actually triggered.
- \`hello-world.md\` author bumped from \`Example Author\` (same as site default) to \`Post Author\` — so the per-post override can be distinguished from the site fallback in the rendered meta tag.
- \`content/about.md\` — a standalone page that hits \`_default/single.html\` instead of \`posts/single.html\`.

### \`.github/workflows/ci.yml\`

Adds a \"Verify rendered output\" step that greps the built \`public/\` tree for 11 expected markers. Any missing marker fails the job via \`set -euxo pipefail\`:

1. \`G-TESTXXXXXX\` + \`googletagmanager\` on a post page → GA template wiring
2. \`bota-theme-example\` on a post page → Disqus template wiring
3. \`fa-github\`, \`fa-linkedin\`, \`fa-twitter\` in home page → social data range + FA resolution
4. \`<meta name=\"author\" content=\"Post Author\">\` on the override post
5. \`<meta name=\"author\" content=\"Example Author\">\` on the fallback post
6. \`>About</h1>\` on the standalone page → \`_default/single.html\`
7. \`min read\` on a post → ReadingTime
8. \`<title>Bota Theme Example</title>\` on home → no title doubling

## Test plan

- All 11 assertions pass locally (\`hugo --themesDir ../.. && <grep chain>\`).
- This PR's CI run is the first real execution of the assertion step.

## Out of scope

- Hugo version matrix (min_version vs latest). Separate PR.
- Testing the \`draft: true\` path (content intentionally excluded from build). Harder to verify without a second build run.
- Testing \`showReadingTime: false\` toggle. Would require a second exampleSite or parametric builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)